### PR TITLE
Allow all characters for title, artist and album

### DIFF
--- a/bandcamp-dl/Bandcamp.py
+++ b/bandcamp-dl/Bandcamp.py
@@ -63,18 +63,6 @@ class Bandcamp:
 
         return new_track
 
-
-    def get_embed_string_block(self, request):
-        embedBlock = request.text.split("var EmbedData = ")
-
-        embedStringBlock = embedBlock[1]
-        embedStringBlock = unicodedata.normalize('NFKD', embedStringBlock).encode('ascii', 'ignore')
-        embedStringBlock = embedStringBlock.split("};")[0] + "};"
-        embedStringBlock = jsobj.read_js_object("var EmbedData = %s" % str(embedStringBlock))
-
-        return embedStringBlock
-
-
     def extract_album_meta_data(self, request):
         album = {}
 
@@ -83,14 +71,13 @@ class Bandcamp:
         block = request.text.split("var TralbumData = ")
 
         stringBlock = block[1]
-        stringBlock = unicodedata.normalize('NFKD', stringBlock).encode('ascii', 'ignore')
+        
         stringBlock = stringBlock.split("};")[0] + "};"
-        stringBlock = jsobj.read_js_object("var TralbumData = %s" % str(stringBlock))
+        stringBlock = jsobj.read_js_object("var TralbumData = %s" % stringBlock)
 
         album['title'] = embedData['EmbedData']['album_title']
         album['artist'] = stringBlock['TralbumData']['artist']
         album['tracks'] = stringBlock['TralbumData']['trackinfo']
-
         return album
 
 
@@ -108,8 +95,7 @@ class Bandcamp:
         embedBlock = request.text.split("var EmbedData = ")
 
         embedStringBlock = embedBlock[1]
-        embedStringBlock = unicodedata.normalize('NFKD', embedStringBlock).encode('ascii', 'ignore')
         embedStringBlock = embedStringBlock.split("};")[0] + "};"
-        embedStringBlock = jsobj.read_js_object("var EmbedData = %s" % str(embedStringBlock))
+        embedStringBlock = jsobj.read_js_object("var EmbedData = %s" % embedStringBlock)
 
         return embedStringBlock

--- a/bandcamp-dl/BandcampDownloader.py
+++ b/bandcamp-dl/BandcampDownloader.py
@@ -39,7 +39,7 @@ class BandcampDownloader():
         path = path.replace("%{album}", track['album'])
         path = path.replace("%{track}", track['track'])
         path = path.replace("%{title}", track['title'])
-        path = "{0}/{1}.{2}".format(self.directory, path, "mp3")
+        path = u"{0}/{1}.{2}".format(self.directory, path, "mp3")
 
         return path
 
@@ -63,7 +63,7 @@ class BandcampDownloader():
 
             filename = self.template_to_path(track_meta)
             dirname = self.create_directory(filename)
-
+            
             try:
                 tmp_file = wgetter.download(track['url'], outdir=dirname)
                 os.rename(tmp_file, filename)


### PR DESCRIPTION
Right now, trying to download an album as this one[0] for example leaves you with empty filenames and folder names. this fixes it.

Also removing duplication of the get_embed_string_block function.
