### PR TITLE
Rearranged configuration handling.

### DIFF
--- a/bandcamp_dl/__main__.py
+++ b/bandcamp_dl/__main__.py
@@ -20,7 +20,7 @@ Iheanyi:
 """
 import argparse
 import logging
-import os
+import pathlib
 import sys
 
 from bandcamp_dl import __version__
@@ -30,41 +30,48 @@ from bandcamp_dl import config
 
 
 def main():
+    # parse config if found, else create it
+    conf = config.Config()
+
     parser = argparse.ArgumentParser()
     parser.add_argument('URL', help="Bandcamp album/track URL", nargs="*")
     parser.add_argument('-v', '--version', action='store_true', help='Show version')
-    parser.add_argument('-d', '--debug', action='store_true', help='Verbose logging')
+    parser.add_argument('-d', '--debug', action='store_true', help='Verbose logging', default=conf.debug)
     parser.add_argument('--artist', help="The artist's slug (from the URL)")
     parser.add_argument('--track', help="he track's slug (from the URL, for use with --artist)")
     parser.add_argument('--album', help="The album's slug (from the URL, for use with --artist)")
     parser.add_argument('--template', help=f"Output filename template, default: "
-                        f"{config.TEMPLATE.replace('%', '%%')}")
-    parser.add_argument('--base-dir', help='Base location of which all files are downloaded')
+                        f"{conf.template.replace('%', '%%')}", default=conf.template)
+    parser.add_argument('--base-dir', help='Base location of which all files are downloaded',
+                        default=conf.base_dir)
     parser.add_argument('-f', '--full-album', help='Download only if all tracks are available',
                         action='store_true')
     parser.add_argument('-o', '--overwrite', action='store_true',
-                        help='Overwrite tracks that already exist. Default is False.')
-    parser.add_argument('-n', '--no-art', help='Skip grabbing album art', action='store_true')
+                        help=f'Overwrite tracks that already exist. Default is {conf.overwrite}.',
+                        default=conf.overwrite)
+    parser.add_argument('-n', '--no-art', help='Skip grabbing album art', action='store_true',
+                        default=conf.no_art)
     parser.add_argument('-e', '--embed-lyrics', help='Embed track lyrics (If available)',
-                        action='store_true')
+                        action='store_true', default=conf.embed_lyrics)
     parser.add_argument('-g', '--group', help='Use album/track Label as iTunes grouping',
-                        action='store_true')
+                        action='store_true', default=conf.group)
     parser.add_argument('-r', '--embed-art', help='Use album/track Label as iTunes grouping',
-                        action='store_true')
-    parser.add_argument('-y', '--no-slugify', action='store_true',
+                        action='store_true', default=conf.embed_art)
+    parser.add_argument('-y', '--no-slugify', action='store_true', default=conf.no_slugify,
                         help='Disable slugification of track, album, and artist names')
-    parser.add_argument('-c', '--ok-chars',
-                        help='Specify allowed chars in slugify, default: ' + config.OK_CHARS)
-    parser.add_argument('-s', '--space-char', help='Specify the char to use in place of spaces, '
-                        'default: ' + config.SPACE_CHAR)
+    parser.add_argument('-c', '--ok-chars', default=conf.ok_chars,
+                        help=f'Specify allowed chars in slugify, default: {conf.ok_chars}')
+    parser.add_argument('-s', '--space-char', help=f'Specify the char to use in place of spaces, '
+                        f'default: {conf.space_char}', default=conf.space_char)
     parser.add_argument('-a', '--ascii-only', help='Only allow ASCII chars (北京 (capital of '
-                        'china) -> bei-jing-capital-of-china)', action='store_true')
+                        'china) -> bei-jing-capital-of-china)', action='store_true',
+                        default=conf.ascii_only)
     parser.add_argument('-k', '--keep-spaces', help='Retain whitespace in filenames',
-                        action='store_true')
+                        action='store_true', default=conf.keep_spaces)
     parser.add_argument('-u', '--keep-upper', help='Retain uppercase letters in filenames',
-                        action='store_true')
+                        action='store_true', default=conf.keep_upper)
     parser.add_argument('--no-confirm', help='Override confirmation prompts. Use with caution',
-                        action='store_true')
+                        action='store_true', default=conf.no_confirm)
 
     arguments = parser.parse_args()
     if arguments.version:
@@ -83,7 +90,7 @@ def main():
     logger.debug(f"Config/Args: {arguments}")
     if not arguments.URL:
         parser.print_usage()
-        sys.stderr.write(f"{os.path.basename(sys.argv[0])}: error: the following arguments are "
+        sys.stderr.write(f"{pathlib.Path(sys.argv[0]).name}: error: the following arguments are "
                          f"required: URL\n")
         sys.exit(2)
 

--- a/bandcamp_dl/config.py
+++ b/bandcamp_dl/config.py
@@ -1,77 +1,69 @@
 import argparse
 import ast
 import json
-import logging
 import os
+import pathlib
+import sys
 
 from bandcamp_dl import __version__
 
 TEMPLATE = '%{artist}/%{album}/%{track} - %{title}'
 OK_CHARS = '-_~'
 SPACE_CHAR = '-'
-USER_HOME = os.path.expanduser('~')
-DEFAULT_CONFIG = {
-    "base_dir": USER_HOME,
-    "template": TEMPLATE,
-    "overwrite": False,
-    "no_art": False,
-    "embed_art": False,
-    "embed_lyrics": False,
-    "group": False,
-    "no_slugify": False,
-    "ok_chars": OK_CHARS,
-    "space_char": SPACE_CHAR,
-    "ascii_only": False,
-    "keep_spaces": False,
-    "keep_upper": False,
-    "no_confirm": False,
-    "debug": False
-}
-
-if os.name == "posix":
-    # Reasoning: https://www.freedesktop.org/wiki/Software/xdg-user-dirs/
-    config_dir = ".config"
-else:
-    # .appname is fine in Windows and MacOS
-    config_dir = ".bandcamp-dl"
-
-config_path = f"{USER_HOME}/{config_dir}/bandcamp-dl.json"
-
-logger = logging.getLogger("bandcamp-dl").getChild("Config")
+USER_HOME = pathlib.Path.home()
+# For Linux/BSD https://www.freedesktop.org/wiki/Software/xdg-user-dirs/
+# For Windows ans MacOS .appname is fine
+CONFIG_PATH = USER_HOME / (".config" if os.name == "posix" else ".bandcamp-dl") / "bandcamp-dl.json"
 
 
-def init_config(parser) -> json or dict:
-    """Create and populate a default config, otherwise load it"""
-    if os.path.isfile(config_path):
-        logger.debug("Config exists, loading...")
-        with open(config_path, "r") as config_file:
-            config_json = json.load(config_file)
-            parser.set_defaults(**config_json)
-            config = arguments = parser.parse_args()
-            first_run = False
-    else:
-        first_run = True
-        if os.path.exists(f"{USER_HOME}/{config_dir}") is False:
-            logger.debug("Config dir doesn't exist, creating...")
-            os.mkdir(f"{USER_HOME}/{config_dir}")
-        with open(config_path, "w") as config_file:
-            # Where config defaults are set/added
-            config = dict(DEFAULT_CONFIG)
-            config_json = json.dumps(config, indent=4)
-            logger.debug("Creating config file...")
-            config_file.write(config_json)
-            parser.set_defaults(**config)
-            config = arguments = parser.parse_args()
+class Config(dict):
 
-    # TODO: Session file should override config, as its essentially replaying manually set args
-    session_file = f"{arguments.base_dir}/{__version__}.not.finished"
+    # TODO: change this to dataclass when support for Python < 3.7 is dropped
+    _defaults = {"base_dir": str(USER_HOME),  # TODO: pass the Path object instead?
+                 "template": TEMPLATE,
+                 "overwrite": False,
+                 "no_art": False,
+                 "embed_art": False,
+                 "embed_lyrics": False,
+                 "group": False,
+                 "no_slugify": False,
+                 "ok_chars": OK_CHARS,
+                 "space_char": SPACE_CHAR,
+                 "ascii_only": False,
+                 "keep_spaces": False,
+                 "keep_upper": False,
+                 "no_confirm": False,
+                 "debug": False}
 
-    if os.path.isfile(session_file) and arguments.URL is None:
-        with open(session_file, "r") as f:
-            parser.set_defaults(**json.load(f))
-            # We don't call parse_args here as we want the session file to overwrite everything
-    elif first_run is False:
-        with open(session_file, "w") as f:
-            f.write("".join(str(vars(arguments))))
+    def __init__(self, dict_=None):
+        if dict_ is None:
+            super().__init__(**Config._defaults)
+        else:
+            super().__init__(**dict_)
+        self.__dict__ = self
+        self._read_write_config()
 
-    return config
+    def _read_write_config(self):
+        if CONFIG_PATH.exists():
+            with pathlib.Path.open(CONFIG_PATH) as fobj:
+                try:
+                    user_config = json.load(fobj)
+                    # change hyphen with undersore
+                    user_config = {k.replace('-', '_'): v for k, v in user_config.items()}
+                    # overwrite defaults with user provided config
+                    self.update_with_dict(user_config)
+                except json.JSONDecodeError:
+                    # NOTE: we don't have logger yet
+                    sys.stderr.write(f"Malformed configuration file `{CONFIG_PATH}'. Check json syntax.\n")
+        else:
+            # No config found - populate it with the defaults
+            with pathlib.Path.open(CONFIG_PATH, mode="w") as fobj:
+                conf = {k.replace('_', '-'): v for k, v in self.items()}
+                json.dump(conf, fobj)
+            sys.stderr.write(f"Configuration has been written to `{CONFIG_PATH}'.\n")
+
+    def update_with_dict(self, dict_):
+        for key, val in dict_.items():
+            if key not in self:
+                continue
+            self[key] = val


### PR DESCRIPTION
Till now, configuration has been done by somehow merging commandline options, reading config file and session files. Design have some flaws, which might occur with unexpected behaviour.

With this patch configuration will be sorted out and following order will be applied:

1. If config file doesn't exists, bandcamp-dl will use defaults and try to write those defaults as a config file.
2. If config does exists, it will be read and options it contain will be applied to the default config.
3. In addition, if anything is passed through commandline, it will be used instead of the default/user configured options.

For example, default config could look as follows:
```json
{
    "base-dir": "/home/username",
    "template": "%{artist}/%{album}/%{track} - %{title}",
    "overwrite": false,
    "no-art": false,
    "embed-art": false,
    "embed-lyrics": false,
    "group": false,
    "no-slugify": false,
    "ok-chars": "-_~",
    "space-char": "-",
    "ascii-only": false,
    "keep-spaces": false,
    "keep-upper": false,
    "no-confirm": false,
    "debug": false
}
```
user might have in his config file following keys:
```json
{
    "base-dir": "/home/username/music",
    "keep-spaces": true,
    "keep-upper": true,
    "unrelated": "whatever"
}
```
and invoke a bandcamp-dl with options:
```console
$ bandcamp-dl --base-dir /tmp https://bandcampurl
```
this in consequence will provide configuration for bandcamp-dl:
```json
{
    "base-dir": "/tmp"
    "template": "%{artist}/%{album}/%{track} - %{title}",
    "overwrite": false,
    "no-art": false,
    "embed-art": false,
    "embed-lyrics": false,
    "group": false,
    "no-slugify": false,
    "ok-chars": "-_~",
    "space-char": "-",
    "ascii-only": false,
    "keep-spaces": true,
    "keep-upper": true,
    "no-confirm": false,
    "debug": false
}
```
in result, default base-dir will be "/tmp" because commandline options have override config option, keep-spaces and keep-upper have override hardcoded defaults.

Note, that options which are not expected will be ignored (like unrelated key in user config). Invalid json configuration will produce appropriate error message, and such config file will be ignored.

Session files are currently broken and will be subject for following fixes.