### PR TITLE
Fix genre delimiter

### DIFF
--- a/bandcamp_dl/bandcamp.py
+++ b/bandcamp_dl/bandcamp.py
@@ -147,7 +147,7 @@ class Bandcamp:
         if art:
             album['art'] = self.get_album_art()
         if genres:
-            album['genres'] = ','.join(page_json['keywords'])
+            album['genres'] = "; ".join(page_json['keywords'])
 
         self.logger.debug(" Album generated..")
         self.logger.debug(" Album URL: %s", album['url'])


### PR DESCRIPTION
This is the standard way that multiple genres are stored. Sorry i closed the previous PR by mistake while renaming branches on my fork