### PR TITLE
Added HTTP requests rate lmiting

### DIFF
--- a/bandcamp_dl/__main__.py
+++ b/bandcamp_dl/__main__.py
@@ -62,10 +62,12 @@ def main():
                         action='store_true', default=conf.no_confirm)
     parser.add_argument('--embed-genres', help='Embed album/track genres',
                         action='store_true', default=conf.embed_genres)
-    parser.add_argument('--truncate-album', metavar='LENGTH', type=int, default=0,
+    parser.add_argument('--truncate-album', metavar='LENGTH', type=int, default=conf.truncate_album,
                         help='Truncate album title to a maximum length. 0 for no limit.')
-    parser.add_argument('--truncate-track', metavar='LENGTH', type=int, default=0,
+    parser.add_argument('--truncate-track', metavar='LENGTH', type=int, default=conf.truncate_track,
                         help='Truncate track title to a maximum length. 0 for no limit.')
+    parser.add_argument('--limit-req-per-minute', type=int, default=conf.limit_req_per_minute,
+                        help='Limit the number of requests sent per minute. 0 for no limit.')
 
 
     arguments = parser.parse_args()
@@ -92,7 +94,7 @@ def main():
                      ('ok_chars', config.OK_CHARS), ('space_char', config.SPACE_CHAR)]:
         if not getattr(arguments, arg):
             setattr(arguments, arg, val)
-    bandcamp = Bandcamp()
+    bandcamp = Bandcamp(limit_req_per_minute=arguments.limit_req_per_minute)
 
     if arguments.artist and arguments.album:
         urls = Bandcamp.generate_album_url(arguments.artist, arguments.album, "album")

--- a/bandcamp_dl/bandcampdownloader.py
+++ b/bandcamp_dl/bandcampdownloader.py
@@ -6,6 +6,7 @@ import shutil
 from mutagen import mp3
 from mutagen import id3
 import requests
+from  requests_ratelimiter import LimiterAdapter
 import slugify
 
 from bandcamp_dl import __version__
@@ -26,7 +27,15 @@ class BandcampDownloader:
         """
         self.headers = {'User-Agent': f'bandcamp-dl/{__version__} '
                         f'(https://github.com/evolution0/bandcamp-dl)'}
+
         self.session = requests.Session()
+        if 0 < config.limit_req_per_minute:
+            # Mount the rate-limiting adapter to the session
+            self.rate_adapter = LimiterAdapter(per_minute=config.limit_req_per_minute)
+            self.session.mount('https://', self.rate_adapter)
+        else:
+            self.rate_adapter = None
+
         self.logger = logging.getLogger("bandcamp-dl").getChild("Downloader")
 
         if type(urls) is str:

--- a/bandcamp_dl/config.py
+++ b/bandcamp_dl/config.py
@@ -44,7 +44,8 @@ class Config(dict):
                  "cover_quality": 0,
                  "untitled_path_from_slug": False,
                  "truncate_album": 0,
-                 "truncate_track": 0}
+                 "truncate_track": 0,
+                 "limit_req_per_minute": 0}
 
     def __init__(self, dict_=None):
         if dict_ is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
     "requests >= 2.32.3",
     "unicode-slugify >= 0.1.5",
     "urllib3 >= 2.2.2",
-    "toml ; python_version < '3.11'"
+    "toml ; python_version < '3.11'",
+    "requests-ratelimiter >= 0.7.0",
 ]
 
 license = {text = "Unlicense"}


### PR DESCRIPTION
Sometimes a download fails with an error message in the form:
```
The Album/Track requested does not exist at: https://...
```

This happens during metadata fetch, before downloading the actual audio and image files. On the first run in a while, this error appears several minutes into the run. On a consecutive run, a different error appears immediately:
```
WARNING:bandcamp-dl.Main:Could not find music grid on the page. No albums found.
```
I reproduced this behavior from two geographically distinct IP addresses when downloading an artist with a large number of tracks using the `--embed-*` options:
```
bandcamp-dl --embed-lyrics --embed-art --embed-genres --artist adarook
```

This happens when the script reaches a per-IP request rate limit and the server begins to return `429 Too Many Requests` for some requests. This can be confirmed by running the script with `--debug` or visiting `bandcamp.com` from a browser with the same IP.

This PR implements an optional global limit on the number of requests sent per minute.

It introduces a new config option, `limit_req_per_minute`, and a command line argument, `--limit-req-per-minute`, with equivalent semantics. The default value `0` disables rate limiting. Positive integers constrain the number of requests sent per minute using a leaky-bucket algorithm.

I did not test this on Python versions other than `3.13.7`. This change adds a new dependency, `requests-ratelimiter`.