### PR TITLE
fix packages

### DIFF
--- a/bandcamp_dl/bandcamp.py
+++ b/bandcamp_dl/bandcamp.py
@@ -6,8 +6,12 @@ import logging
 import bs4
 import requests
 from requests.adapters import HTTPAdapter
-from urllib3.util import create_urllib3_context
-from urllib.parse import urlparse, urlunparse, urljoin
+from urllib.parse import urljoin
+
+try:
+    from urllib3.util import create_urllib3_context
+except ImportError:
+    from urllib3.util.ssl_ import create_urllib3_context
 
 from bandcamp_dl import __version__
 from bandcamp_dl.bandcampjson import BandcampJSON
@@ -24,7 +28,8 @@ class SSLAdapter(HTTPAdapter):
     def proxy_manager_for(self, *args, **kwargs):
         kwargs['ssl_context'] = self.ssl_context
         return super().proxy_manager_for(*args, **kwargs)
-    
+
+
 # Create the SSL context with the custom ciphers
 ctx = create_urllib3_context()
 ctx.load_default_certs()
@@ -57,7 +62,7 @@ class Bandcamp:
         self.soup = None
         self.tracks = None
         self.logger = logging.getLogger("bandcamp-dl").getChild("Main")
-        
+
         # Mount the adapter with the custom SSL context to the session
         self.session = requests.Session()
         self.adapter = SSLAdapter(ssl_context=ctx)
@@ -84,7 +89,6 @@ class Bandcamp:
             self.logger.debug(" Status code: %s", response.status_code)
             print(f"The Album/Track requested does not exist at: {url}")
             sys.exit(2)
-
 
         try:
             self.soup = bs4.BeautifulSoup(response.text, "lxml")
@@ -132,7 +136,7 @@ class Bandcamp:
                 else:
                     self.logger.debug(f" Could not find position for track: {full_track_url}")
                     track['track_num'] = self.tracks.index(track) + 1
-        
+
         album_release = page_json['album_release_date']
         if album_release is None:
             album_release = page_json['current']['release_date']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,13 @@ classifiers=[
 requires-python = ">=3.4"
 version = "0.0.18"
 dependencies = [
-    "beautifulsoup4 >= 4.13.0b2",
-    "demjson3 >= 3.0.6",
-    "mutagen >= 1.47.0",
-    "requests >= 2.32.3",
-    "unicode-slugify @ git+https://github.com/mozilla/unicode-slugify.git@refs/pull/41/head",
-    "urllib3 >= 2.2.2",
-    "toml ; python_version < '3.11'"
+    "beautifulsoup4==4.10.0",
+    "demjson3==3.0.6",
+    "mutagen==1.43.1",
+    "requests==2.25.1",
+    "unicode-slugify==0.1.5",
+    "urllib3==1.26.20",
+    "toml==0.10.2"
 ]
 
 license = {text = "Unlicense"}

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,154 @@
+version = 1
+requires-python = ">=3.4"
+
+[[package]]
+name = "bandcamp-downloader"
+version = "0.0.18"
+source = { editable = "." }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "demjson3" },
+    { name = "mutagen" },
+    { name = "requests" },
+    { name = "toml" },
+    { name = "unicode-slugify" },
+    { name = "urllib3" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "beautifulsoup4", specifier = "==4.10.0" },
+    { name = "demjson3", specifier = "==3.0.6" },
+    { name = "mutagen", specifier = "==1.43.1" },
+    { name = "requests", specifier = "==2.25.1" },
+    { name = "toml", specifier = "==0.10.2" },
+    { name = "unicode-slugify", specifier = "==0.1.5" },
+    { name = "urllib3", specifier = "==1.26.20" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/69/daeee6d8f22c997e522cdbeb59641c4d31ab120aba0f2c799500f7456b7e/beautifulsoup4-4.10.0.tar.gz", hash = "sha256:c23ad23c521d818955a4151a67d81580319d4bf548d3d49f4223ae041ff98891", size = 399890 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/bf/f0f194d3379d3f3347478bd267f754fc68c11cbf2fe302a6ab69447b1417/beautifulsoup4-4.10.0-py3-none-any.whl", hash = "sha256:9a315ce70049920ea4572a4055bc4bd700c940521d36fc858205ad4fcde149bf", size = 97398 },
+]
+
+[[package]]
+name = "certifi"
+version = "2021.10.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/ae/d26450834f0acc9e3d1f74508da6df1551ceab6c2ce0766a593362d6d57f/certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872", size = 151214 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/45/946c02767aabb873146011e665728b680884cd8fe70dde973c640e45b775/certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569", size = 149195 },
+]
+
+[[package]]
+name = "chardet"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/2d/9cdc2b527e127b4c9db64b86647d567985940ac3698eeabc7ffaccb4ea61/chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa", size = 1907771 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/c7/fa589626997dd07bd87d9269342ccb74b1720384a4d739a1872bd84fbe68/chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5", size = 178743 },
+]
+
+[[package]]
+name = "demjson3"
+version = "3.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/d2/6a81a9b5311d50542e11218b470dafd8adbaf1b3e51fc1fddd8a57eed691/demjson3-3.0.6.tar.gz", hash = "sha256:37c83b0c6eb08d25defc88df0a2a4875d58a7809a9650bd6eee7afd8053cdbac", size = 131477 }
+
+[[package]]
+name = "idna"
+version = "2.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/b7/e0e3c1c467636186c39925827be42f16fee389dc404ac29e930e9136be70/idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6", size = 175616 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/38/928ddce2273eaa564f6f50de919327bf3a00f091b5baba8dfa9460f3a8a8/idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0", size = 58811 },
+]
+
+[[package]]
+name = "mutagen"
+version = "1.43.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a2/af03414b37e2e3c1fcdfadfbc692652198767c5d822ad3a3b3a949bac86d/mutagen-1.43.1.tar.gz", hash = "sha256:d873baeb7815311d3420aab0a1d83f050f628228cbc2d6045a14a16460411bc9", size = 1151423 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/e7/537440fd53f8f9fc178c4bf961a85e739a05d9a6abc09868ffd2f2f4cce0/mutagen-1.43.1-py2.py3-none-any.whl", hash = "sha256:bfb14e9b57bef636a7ea4e2728dc6dbbbd279794365ce4b8593c855e22b10c95", size = 212837 },
+]
+
+[[package]]
+name = "requests"
+version = "2.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "chardet" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/47/c14abc08432ab22dc18b9892252efaf005ab44066de871e72a38d6af464b/requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804", size = 102161 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/c1/24814557f1d22c56d50280771a17307e6bf87b70727d975fd6b2ce6b014a/requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e", size = 61216 },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
+name = "soupsieve"
+version = "1.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/a0/b40ed5dcd4f64c521cdc29cfa7c4847f521c590f7835099307089eaef3ad/soupsieve-1.9.6.tar.gz", hash = "sha256:7985bacc98c34923a439967c1a602dc4f1e15f923b6fcf02344184f86cc7efaa", size = 99109 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/36/f35056eb9978a622bbcedc554993d10777e3c6ff1ca24cde53f4be9c5fc4/soupsieve-1.9.6-py2.py3-none-any.whl", hash = "sha256:feb1e937fa26a69e08436aad4a9037cd7e1d4c7212909502ba30701247ff8abd", size = 33484 },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588 },
+]
+
+[[package]]
+name = "unicode-slugify"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+    { name = "unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/37/c82a28893c7bfd881c011cbebf777d2a61f129409d83775f835f70e02c20/unicode-slugify-0.1.5.tar.gz", hash = "sha256:25f424258317e4cb41093e2953374b3af1f23097297664731cdb3ae46f6bd6c3", size = 5784 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/a1/53414fffc089249eee742c1ce04b22761980d2aaea37e23b94775ff51007/unicode_slugify-0.1.5-py3-none-any.whl", hash = "sha256:33a11c0ac901f7220659dd0dd6f232cf39637dfd1b9f5f35ef5ead9fef696879", size = 6358 },
+]
+
+[[package]]
+name = "unidecode"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/31/245d8a384939aa0ee152c76fc62890f79f35fc41cd12839f5df268d9081d/Unidecode-1.2.0.tar.gz", hash = "sha256:8d73a97d387a956922344f6b74243c2c6771594659778744b2dbdaad8f6b727d", size = 216042 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/25/723487ca2a52ebcee88a34d7d1f5a4b80b793f179ee0f62d5371938dfa01/Unidecode-1.2.0-py2.py3-none-any.whl", hash = "sha256:12435ef2fc4cdfd9cf1035a1db7e98b6b047fe591892e81f34e94959591fad00", size = 241669 },
+]
+
+[[package]]
+name = "urllib3"
+version = "1.26.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225 },
+]


### PR DESCRIPTION
packages were not hard locked and installing via pip/uv produced an error

these changes allow out of the box installation with both pip and uv, and support python3.13+ versions as well

error before
```
Traceback (most recent call last):
  File "$HOME/venv/bin/bandcamp-dl", line 6, in <module>
    sys.exit(main())
             ~~~~^^
  File "$HOME/venv/lib/python3.13/site-packages/bandcamp_dl/__main__.py", line 132, in main
    bandcamp_downloader.start(album)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "$HOME/venv/lib/python3.13/site-packages/bandcamp_dl/bandcampdownloader.py", line 52, in start
    self.download_album(album)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "$HOME/venv/lib/python3.13/site-packages/bandcamp_dl/bandcampdownloader.py", line 151, in download_album
    filepath = self.template_to_path(track_meta, self.config.ascii_only,
                                     self.config.ok_chars, self.config.space_char,
                                     self.config.keep_spaces, self.config.keep_upper)
  File "$HOME/venv/lib/python3.13/site-packages/bandcamp_dl/bandcampdownloader.py", line 91, in template_to_path
    self.logger.debug(f'Track artist is None, replacing with {slugify_preset(track["albumartist"])}')
                                                              ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "$HOME/venv/lib/python3.13/site-packages/bandcamp_dl/bandcampdownloader.py", line 71, in slugify_preset
    slugged = slugify.slugify(content, ok=ok_chars, only_ascii=ascii_only,
                              spaces=keep_space, lower=not keep_upper,
                              space_replacement=space_char)
TypeError: slugify() got an unexpected keyword argument 'ok'
```