### PR TITLE
fix: set album_art when cover.jpg already exists

### DIFF
--- a/bandcamp_dl/bandcampdownloader.py
+++ b/bandcamp_dl/bandcampdownloader.py
@@ -172,15 +172,18 @@ class BandcampDownloader:
 
             self.logger.debug(" Current file:\n\t%s", filepath)
 
-            if album['art'] and not os.path.exists(dirname + "/cover.jpg"):
+            cover_path = dirname + "/cover.jpg"
+            if album['art'] and not os.path.exists(cover_path):
                 try:
-                    with open(dirname + "/cover.jpg", "wb") as f:
+                    with open(cover_path, "wb") as f:
                         r = self.session.get(album['art'], headers=self.headers)
                         f.write(r.content)
-                    self.album_art = dirname + "/cover.jpg"
+                    self.album_art = cover_path
                 except Exception as e:
                     print(e)
                     print("Couldn't download album art.")
+            elif os.path.exists(cover_path):
+                self.album_art = cover_path
 
             attempts = 0
             skip = False


### PR DESCRIPTION
## Bug
https://github.com/Evolution0/bandcamp-dl/issues/287 — Re-running the downloader when cover.jpg already exists crashes with `AttributeError: 'BandcampDownloader' object has no attribute 'album_art'`.

## Fix
When the cover image already exists on disk from a previous (interrupted) download, the code skips the download but never assigns `self.album_art`. The subsequent call to `write_id3_tags()` then fails because it tries to open `self.album_art` for embedding.

This PR adds an `elif` branch that sets `self.album_art` to the existing cover path when the file is already present, so ID3 tag writing and the cleanup step at the end both work correctly on resumed downloads.

Also extracts the repeated `dirname + "/cover.jpg"` into a local `cover_path` variable for clarity.

## Testing
Verified the logic against the traceback in #287:
1. First run downloads cover.jpg → `self.album_art` is set ✓
2. Interrupted, re-run → cover.jpg exists, elif branch fires → `self.album_art` is set ✓
3. `write_id3_tags()` succeeds in both cases ✓

Happy to address any feedback.

Greetings, saschabuehrle